### PR TITLE
Flywheel fix for expressions

### DIFF
--- a/cas/src/expressions.rs
+++ b/cas/src/expressions.rs
@@ -18,6 +18,8 @@ pub use product::Product;
 pub use sum::Sum;
 pub use exponent::Exponent;
 
+use self::product::product_of;
+
 pub trait IExpression {
     /**
      * Creates a string representing the expression and it's children
@@ -68,7 +70,23 @@ pub enum Expression {
 
 impl PartialEq for Expression {
     fn eq(&self, other: &Self) -> bool {
-        self.as_stringable().id() == other.as_stringable().id()
+        let first: Arc<dyn IExpression> = match self {
+            Expression::Negation(p) => p.clone(),
+            Expression::Integer(p) => p.clone(),
+            Expression::Product(p) => p.clone(),
+            Expression::Exponent(p) => p.clone(),
+            Expression::Sum(p) => p.clone(),
+        };
+        let second: Arc<dyn IExpression> = match other {
+            Expression::Negation(p) => p.clone(),
+            Expression::Integer(p) => p.clone(),
+            Expression::Product(p) => p.clone(),
+            Expression::Exponent(p) => p.clone(),
+            Expression::Sum(p) => p.clone(),
+        };
+
+
+        Arc::ptr_eq(&first, &second)
     }
 }
 
@@ -90,10 +108,6 @@ impl Expression {
         }
     }
 
-    pub fn get_instance(id: ExpressionId) -> Option<ExpressionPtr> {
-        let result = EXPRESSION_INSTANCES.lock().unwrap().get(&id).cloned();
-        result
-    }
 }
 
 impl Display for Expression {

--- a/cas/src/expressions/integer.rs
+++ b/cas/src/expressions/integer.rs
@@ -49,9 +49,12 @@ mod tests {
 
     #[test]
     fn flywheel_integer() {
+        let i0 = Integer::of(1);
         let i1 = Integer::of(1);
         let i2 = Integer::of(2);
         assert_ne!(i1.as_stringable().id(), i2.as_stringable().id(), 
         "Integer not generating unique flywheel hashes");
+
+        assert_eq!(i0, i1);
     }
 }

--- a/cas/src/expressions/product.rs
+++ b/cas/src/expressions/product.rs
@@ -28,11 +28,11 @@ impl Product {
             tmp
         };
 
-        if let Ok(instances) = EXPRESSION_INSTANCES.lock() {
-            let result = instances.get(&id);
-            if result.is_some() {
-                return Ok(result.unwrap().clone());
-            }
+        let mut instances = EXPRESSION_INSTANCES.lock().unwrap();
+
+        let result = instances.get(&id);
+        if result.is_some() {
+            return Ok(result.unwrap().clone());
         }
 
         let result = Product {
@@ -41,10 +41,7 @@ impl Product {
         match result.rep_ok() {
             true => {
                 let pointer = Expression::Product(Arc::new(result));
-                EXPRESSION_INSTANCES
-                    .lock()
-                    .unwrap()
-                    .insert(id, pointer.clone());
+                instances.insert(id, pointer.clone());
                 Ok(pointer)
             }
             false => Err(()),

--- a/cas/src/expressions/sum.rs
+++ b/cas/src/expressions/sum.rs
@@ -19,11 +19,11 @@ impl Sum {
 
         let id = id_from_terms(terms);
 
-        if let Ok(instances) = EXPRESSION_INSTANCES.lock() {
-            let result = instances.get(&id);
-            if result.is_some() {
-                return Ok(result.unwrap().clone());
-            }
+        let mut instances = EXPRESSION_INSTANCES.lock().unwrap();
+
+        let result = instances.get(&id);
+        if result.is_some() {
+            return Ok(result.unwrap().clone());
         }
 
         let result = Sum {
@@ -31,7 +31,7 @@ impl Sum {
         };
 
         let pointer = Expression::Sum(Arc::new(result));
-        EXPRESSION_INSTANCES.lock().unwrap().insert(id, pointer.clone());
+        instances.insert(id, pointer.clone());
         Ok(pointer)
     }
 


### PR DESCRIPTION
Added tests to expression subclasses testing flywheel implementation. Changed Equality implementation for Expression enum to check for referential equality. Fixed some broken expression.id() methods.
Fix data race in flywheel in expression subclasses. We now lock the shared EXPRESSION_INSTANCES variable
for the duration of Integer::of(...) etc. This is necessary because what it had been doing is locking it twice, once to check 
if the expression already existed, then unlock and lock again to add the created one. This allowed another thread to create another expression instance between the two locks.