### PR TITLE
Draft parsing JSON expressions from the front end

### DIFF
--- a/cas/src/expressions.rs
+++ b/cas/src/expressions.rs
@@ -11,12 +11,16 @@ pub mod integer;
 pub mod negation;
 pub mod product;
 pub mod sum;
+pub mod variable;
+mod read_from_json;
 
 pub use integer::Integer;
 pub use negation::Negation;
 pub use product::Product;
 pub use sum::Sum;
 pub use exponent::Exponent;
+pub use variable::Variable;
+pub use read_from_json::*;
 
 pub trait IExpression {
     /**
@@ -64,6 +68,7 @@ pub enum Expression {
     Product(Arc<Product>),
     Exponent(Arc<Exponent>),
     Sum(Arc<Sum>),
+    Variable(Arc<Variable>),
 }
 
 impl PartialEq for Expression {
@@ -74,6 +79,7 @@ impl PartialEq for Expression {
             Expression::Product(p) => p.clone(),
             Expression::Exponent(p) => p.clone(),
             Expression::Sum(p) => p.clone(),
+            Expression::Variable(p) => p.clone(),
         };
         let second: Arc<dyn IExpression> = match other {
             Expression::Negation(p) => p.clone(),
@@ -81,6 +87,7 @@ impl PartialEq for Expression {
             Expression::Product(p) => p.clone(),
             Expression::Exponent(p) => p.clone(),
             Expression::Sum(p) => p.clone(),
+            Expression::Variable(p) => p.clone(),
         };
 
 
@@ -103,9 +110,9 @@ impl Expression {
             Expression::Product(p) => p.clone(),
             Expression::Exponent(e) => e.clone(),
             Expression::Sum(s) => s.clone(),
+            Expression::Variable(v) => v.clone(),
         }
     }
-
 }
 
 impl Display for Expression {

--- a/cas/src/expressions/read_from_json.rs
+++ b/cas/src/expressions/read_from_json.rs
@@ -1,0 +1,78 @@
+use crate::convenience_expressions::power;
+
+use super::{Expression, sum::sum_of, Integer, product::product_of, variable::Variable};
+use serde_json::{Value, from_str};
+
+/// Reads expression objects out of JSON expressions
+
+/**
+* Reads a JSON string into an expression or give an error message.
+*/
+pub fn read_object_from_json(json: &str) -> Result<Expression, String> {
+    let obj = match from_str(json) {
+        Ok(val) => val,
+        Err(_) => return Err("Not a json".to_owned()),
+    };
+
+    read_obj_rec(&obj)
+}
+
+fn read_obj_rec(object: &Value) -> Result<Expression, String> {
+    match object {
+        Value::Array(arr) => {
+            match arr.first().unwrap().as_str().unwrap() {
+                "Sum" => {
+                    let terms = arr.iter().skip(1).map(|term| read_obj_rec(term));
+
+                    for t in terms.clone() {
+                        if t.is_err() {
+                            return Err("Undefined sub expression".to_owned());
+                        }
+                    }
+
+                    Ok(sum_of(&terms.map(|term| term.unwrap()).collect::<Vec<Expression>>()))
+                },
+                "Product" => {
+                    let factors = arr.iter().skip(1).map(|f| read_obj_rec(f));
+                    if factors.clone().any(|f| f.is_err()) {
+                        return Err("Undefined sub expression".to_owned());
+                    }
+                    Ok(product_of(&factors.map(|f| f.unwrap()).collect::<Vec<Expression>>()))
+                },
+                "Divide" => {
+                    panic!("TODO: Divide not implemented")
+                },
+                "Exponent" => {
+                    Ok(power(read_obj_rec(&arr[1])?, read_obj_rec(&arr[2])?)) 
+                },
+                s => panic!("Unimplemented operation {}", s)
+            }
+        },
+        Value::Object(obj) => {
+            if obj.contains_key("num") {
+                Ok(Integer::of(obj["num"].as_u64().unwrap() as u32))
+            } else if obj.contains_key("var") {
+                Ok(Variable::of(obj["var"].as_str().unwrap()))
+            }else {
+                Err(format!("Invalid object {:?}", obj))
+            }
+        }
+        _ => panic!("Not implemented {}, {}", object, object.as_str().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::expressions::Integer;
+
+    use super::read_object_from_json;
+
+    #[test]
+    fn test_1() {
+        let e = read_object_from_json("{\"num\": 1}");
+        assert_eq!(e.unwrap(), Integer::of(1));
+    }
+}
+
+
+

--- a/cas/src/expressions/variable.rs
+++ b/cas/src/expressions/variable.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use crate::expressions::IExpression;
+
+use super::{Expression, EXPRESSION_INSTANCES, ExpressionPtr};
+
+#[derive(PartialEq, Eq, Hash, Debug)]
+pub struct Variable {
+    symbol: String,
+}
+
+impl Variable {
+    pub fn of(symbol: &str) -> ExpressionPtr {
+        let id = get_id(symbol);
+
+        let mut instances = EXPRESSION_INSTANCES.lock().unwrap();
+
+        if let Some(result) = instances.get(&id) {
+            return result.clone();
+        }
+
+        let result = Expression::Variable(Arc::new(Variable {
+            symbol: symbol.to_owned()
+        }));
+
+        instances.insert(id, result.clone());
+        result
+    }
+
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+}
+
+fn get_id(sym: &str) -> String {
+    format!("var{}", sym)
+}
+
+impl IExpression for Variable {
+    fn to_unambigious_string(&self) -> String {
+        self.symbol.clone()
+    }
+
+    fn to_math_xml(&self) -> String {
+        format!("<mi>{}</mi>", self.symbol)
+    }
+
+    fn id(&self) -> String {
+        get_id(&self.symbol)
+    }
+}
+

--- a/cas/src/graph_traversal.rs
+++ b/cas/src/graph_traversal.rs
@@ -41,6 +41,9 @@ fn complexity(a: &ExpressionPtr) -> u32 {
         Expression::Integer(_) => {
             1
         },
+        Expression::Variable(_) => {
+            1
+        },
     }
 }
 

--- a/cas/src/lib.rs
+++ b/cas/src/lib.rs
@@ -10,7 +10,7 @@ mod convenience_expressions;
 
 use convenience_expressions::{sum, product, i, power};
 use deriver::Deriver;
-use expressions::{Expression, ExpressionId, ExpressionPtr, Integer, Exponent};
+use expressions::{Expression, ExpressionId, ExpressionPtr, Integer, Exponent, read_object_from_json};
 use graph::Graph;
 use graph_traversal::{expression_complexity_cmp, Path};
 use petgraph::{visit::IntoNodeReferences, algo::astar};
@@ -34,12 +34,16 @@ pub fn find_equivalents(exp: Expression) -> Graph {
 }
 
 /**
-* Takes an ascii math expression and returns a JSON object
-* contianing a sequence of steps leading to a reduced expression.
+* Takes an expression in JSON form, parses, simplifies then returns
+* a JSON containing steps to solve it, or an error message.
+* TODO: Actual spec for return type and input JSON
 */
 #[wasm_bindgen]
-pub fn simplify_with_steps(_ascii_expression: &str) -> String {
-    let expression: ExpressionPtr = product(sum(i(1), i(1)), power(i(42), i(69)));
+pub fn simplify_with_steps(json_expression: &str) -> String {
+    let expression = match read_object_from_json(json_expression) {
+        Ok(exp) => exp,
+        Err(msg) => return msg,
+    };
     let mut graph = Graph::new();
     let deriver = Deriver::new();
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".webpack/main",
   "scripts": {
     "test": "jest",
-    "format": "prettier --write **/*",
+    "format": "prettier --write ui/**/*",
     "build": "npx webpack",
     "build-grammar": "java -jar ~/antlr4.jar -Dlanguage=TypeScript -visitor ./ui/mathlib/userinput/arithmetic.g4",
     "serve": "npx webpack serve"

--- a/ui/LoadWasmStepsPage.ts
+++ b/ui/LoadWasmStepsPage.ts
@@ -1,5 +1,9 @@
 import { EditableMathView } from "./mathlib/uielements/EditableMathView"
 import initWasm, {simplify_with_steps} from "../cas/pkg"
+import { parseExpression } from "./mathlib/userinput/AntlrMathParser"
+import { Expression } from "./mathlib/expressions/Expression"
+import { Integer } from "./mathlib/expressions/Integer"
+import { Sum } from "./mathlib/expressions/Sum"
 
 declare const MathJax: any
 
@@ -18,10 +22,23 @@ export async function loadWasmStepsBackend(): Promise<void> {
     problemViewDiv.appendChild(problemView)
 
     inputView.focus()
+    let parsedExpression: Expression;
 
     inputView.addEventListener("keyup", () => {
-        let result = JSON.parse(simplify_with_steps(inputView.textContent))
-        console.log(result[0])
+        parsedExpression = parseExpression(inputView.value) ?? parsedExpression
+        if (parsedExpression == undefined) return
+
+        let r = simplify_with_steps(parsedExpression.toJSON())
+
+        let result: String;
+        try {
+            result = JSON.parse(r);
+        } catch (e) {
+            console.log("Implementation error: Received error msg from backend:")
+            console.log(r)
+            return
+        }
+
         problemViewDiv.innerHTML = result[0]
         solutionView.innerHTML = "<math display='block'>" + result[0] + "</math>"
         MathJax.typeset([problemViewDiv])

--- a/ui/mathlib/expressions/Derivative.ts
+++ b/ui/mathlib/expressions/Derivative.ts
@@ -68,6 +68,10 @@ export class Derivative extends Expression {
         return NaN
     }
 
+    toJSON(): string {
+        return `["Derivative", ${this.exp.toJSON()}, ${this.relativeTo.toJSON()}]`
+    }
+
     public readonly isConstant: boolean
     public readonly childCount: number
 }

--- a/ui/mathlib/expressions/Exponent.ts
+++ b/ui/mathlib/expressions/Exponent.ts
@@ -49,6 +49,10 @@ export class Exponent extends Expression {
         return Math.pow(this.base.evaluate(values), this.power.evaluate(values))
     }
 
+    toJSON(): string {
+        return `["Exponent", ${this.base.toJSON()}, ${this.power.toJSON()}]`
+    }
+
     private constructor(base: Expression, power: Expression) {
         super()
         this.base = base

--- a/ui/mathlib/expressions/Expression.ts
+++ b/ui/mathlib/expressions/Expression.ts
@@ -3,12 +3,20 @@ import { VariableValueMap } from "../VariableValueMap"
 import { IntegerType } from "./Integer"
 import { MathElement } from "./MathElement"
 
+export interface JSONMath {
+    /**
+     * Produces a JSON array representing the expression.
+     * TODO: Make actual specification
+     */
+    toJSON(): string
+}
+
 /**
  * Base of all mathematical expressions.
  * All children should implement fly-wheel pattern.
  * All children should be immutable.
  */
-export abstract class Expression extends MathGraphNode implements MathElement {
+export abstract class Expression extends MathGraphNode implements MathElement, JSONMath {
     public abstract toMathXML(): string
 
     /**
@@ -73,4 +81,6 @@ export abstract class Expression extends MathGraphNode implements MathElement {
      *          evaluating the expression.
      */
     public abstract evaluate(values: VariableValueMap): number
+
+    public abstract toJSON(): string;
 }

--- a/ui/mathlib/expressions/Expression.ts
+++ b/ui/mathlib/expressions/Expression.ts
@@ -16,7 +16,10 @@ export interface JSONMath {
  * All children should implement fly-wheel pattern.
  * All children should be immutable.
  */
-export abstract class Expression extends MathGraphNode implements MathElement, JSONMath {
+export abstract class Expression
+    extends MathGraphNode
+    implements MathElement, JSONMath
+{
     public abstract toMathXML(): string
 
     /**
@@ -82,5 +85,5 @@ export abstract class Expression extends MathGraphNode implements MathElement, J
      */
     public abstract evaluate(values: VariableValueMap): number
 
-    public abstract toJSON(): string;
+    public abstract toJSON(): string
 }

--- a/ui/mathlib/expressions/Fraction.ts
+++ b/ui/mathlib/expressions/Fraction.ts
@@ -57,6 +57,10 @@ export class Fraction extends Expression {
         )
     }
 
+    toJSON(): string {
+        return `["Divide", ${this.numerator.toJSON()}, ${this.denominator.toJSON()}]`
+    }
+
     public readonly childCount: number
 }
 

--- a/ui/mathlib/expressions/Integer.ts
+++ b/ui/mathlib/expressions/Integer.ts
@@ -51,6 +51,10 @@ export class Integer extends Expression {
         return this.value
     }
 
+    public toJSON(): string {
+        return `{"num": ${this.value}}`;
+    }
+
     public readonly value: number
     public readonly isReducible: boolean = false
 

--- a/ui/mathlib/expressions/Integer.ts
+++ b/ui/mathlib/expressions/Integer.ts
@@ -52,7 +52,7 @@ export class Integer extends Expression {
     }
 
     public toJSON(): string {
-        return `{"num": ${this.value}}`;
+        return `{"num": ${this.value}}`
     }
 
     public readonly value: number

--- a/ui/mathlib/expressions/Integral.ts
+++ b/ui/mathlib/expressions/Integral.ts
@@ -73,6 +73,10 @@ export class Integral extends Expression {
         return NaN
     }
 
+    toJSON(): string {
+        return `["Integral", ${this.integrand.toJSON()}]`
+    }
+
     public readonly childCount: number
 }
 

--- a/ui/mathlib/expressions/Logarithm.ts
+++ b/ui/mathlib/expressions/Logarithm.ts
@@ -44,6 +44,10 @@ export class Logarithm extends Expression {
         )
     }
 
+    toJSON(): string {
+        return `["Log", ${this.base.toJSON()}, ${this.exp.toJSON()}]`
+    }
+
     public readonly isConstant: boolean
     public readonly childCount: number
 

--- a/ui/mathlib/expressions/Product.ts
+++ b/ui/mathlib/expressions/Product.ts
@@ -187,6 +187,14 @@ export class Product extends Expression {
             .reduce((a, b) => a * b)
     }
 
+    toJSON(): string {
+        let result = '["Product"'
+        for (const factor of this.factors) {
+            result += ", " + factor.toJSON()
+        }
+        return result + "]"
+    }
+
     // At least 2 elements, order matters
     public readonly factors: Expression[]
     public readonly class: string = ProductType

--- a/ui/mathlib/expressions/Sum.ts
+++ b/ui/mathlib/expressions/Sum.ts
@@ -111,6 +111,15 @@ export class Sum extends Expression {
             .reduce((a, b) => a + b)
     }
 
+    toJSON(): string {
+        let result = '["Sum"'
+        for (const term of this.terms) {
+            result += ", " + term.toJSON()
+        }
+        return result + "]"
+
+    }
+
     public readonly class = SumType
     /**
      * Ordered, immutable

--- a/ui/mathlib/expressions/Sum.ts
+++ b/ui/mathlib/expressions/Sum.ts
@@ -117,7 +117,6 @@ export class Sum extends Expression {
             result += ", " + term.toJSON()
         }
         return result + "]"
-
     }
 
     public readonly class = SumType

--- a/ui/mathlib/expressions/Variable.ts
+++ b/ui/mathlib/expressions/Variable.ts
@@ -34,6 +34,10 @@ export class Variable extends Expression {
         return values.valueOf(this)
     }
 
+    toJSON(): string {
+        return `{"var": "${this.symbol}"}`
+    }
+
     public readonly symbol: string
     public readonly isReducible: boolean = false
 

--- a/ui/mathlib/tests/JSON-expression-serialization.test.ts
+++ b/ui/mathlib/tests/JSON-expression-serialization.test.ts
@@ -1,9 +1,9 @@
-import { Exponent } from "../expressions/Exponent";
-import { Fraction } from "../expressions/Fraction";
+import { Exponent } from "../expressions/Exponent"
+import { Fraction } from "../expressions/Fraction"
 import { Integer } from "../expressions/Integer"
-import { Product } from "../expressions/Product";
-import { Sum } from "../expressions/Sum";
-import { Logarithm } from "../expressions/Logarithm";
+import { Product } from "../expressions/Product"
+import { Sum } from "../expressions/Sum"
+import { Logarithm } from "../expressions/Logarithm"
 
 test("Expression objects serialize to JSON correctyl", () => {
     let i = Integer.of(69).toJSON()
@@ -19,7 +19,7 @@ test("Expression objects serialize to JSON correctyl", () => {
     expect(e == `["Exponent", {"num": 1}, {"num": 2}]`)
 
     let f = Fraction.of(Integer.of(1), Integer.of(2)).toJSON()
-    expect(f = `["Divide", {"num": 1}, {"num": 2}]`)
+    expect((f = `["Divide", {"num": 1}, {"num": 2}]`))
 
     let l = Logarithm.of(Integer.of(1), Integer.of(2)).toJSON()
     expect(l == `["Logarithrm", {"num": 1}, {"num": 2}]`)

--- a/ui/mathlib/tests/JSON-expression-serialization.test.ts
+++ b/ui/mathlib/tests/JSON-expression-serialization.test.ts
@@ -1,0 +1,26 @@
+import { Exponent } from "../expressions/Exponent";
+import { Fraction } from "../expressions/Fraction";
+import { Integer } from "../expressions/Integer"
+import { Product } from "../expressions/Product";
+import { Sum } from "../expressions/Sum";
+import { Logarithm } from "../expressions/Logarithm";
+
+test("Expression objects serialize to JSON correctyl", () => {
+    let i = Integer.of(69).toJSON()
+    expect(i == `"{"num": 69}"`)
+
+    let s = Sum.of([Integer.of(1), Integer.of(1)]).toJSON()
+    expect(s == `["Sum", {"num": 1}, {"num": 1}]`)
+
+    let p = Product.of([Integer.of(1), Integer.of(1)]).toJSON()
+    expect(p == `["Product", {"num": 1}, {"num": 1}]`)
+
+    let e = Exponent.of(Integer.of(1), Integer.of(2)).toJSON()
+    expect(e == `["Exponent", {"num": 1}, {"num": 2}]`)
+
+    let f = Fraction.of(Integer.of(1), Integer.of(2)).toJSON()
+    expect(f = `["Divide", {"num": 1}, {"num": 2}]`)
+
+    let l = Logarithm.of(Integer.of(1), Integer.of(2)).toJSON()
+    expect(l == `["Logarithrm", {"num": 1}, {"num": 2}]`)
+})

--- a/ui/mathlib/userinput/AntlrMathParser.ts
+++ b/ui/mathlib/userinput/AntlrMathParser.ts
@@ -16,20 +16,24 @@ import { assert } from "../util/assert"
  * @param input See the gramar file (.g4)
  * @returns
  */
-export function parseExpression(input: string): Expression {
-    const stream = new CharStream(input, true)
-    const lexer = new arithmeticLexer(stream)
-    const tokens = new CommonTokenStream(lexer)
-    const parser = new arithmeticParser(tokens)
-    //parser.buildParseTrees = true
-    const tree = parser.expression()
+export function parseExpression(input: string): Expression | null {
+    try {
+        const stream = new CharStream(input, true)
+        const lexer = new arithmeticLexer(stream)
+        const tokens = new CommonTokenStream(lexer)
+        const parser = new arithmeticParser(tokens)
+        //parser.buildParseTrees = true
+        const tree = parser.expression()
 
-    tree.accept<OpenContext>(new Flattener())
+        tree.accept<OpenContext>(new Flattener())
 
-    // Print debug info
-    //tree.accept(new PrintVisitor())
+        // Print debug info
+        //tree.accept(new PrintVisitor())
 
-    const result = tree.accept<Expression>(new ExpressionVisitor())
-    assert(result != null && result != undefined)
-    return result
+        const result = tree.accept<Expression>(new ExpressionVisitor())
+        // assert(result != null && result != undefined)
+        return result
+    } catch (e) {
+        return null
+    }
 }


### PR DESCRIPTION
I decided it would be faster to parse the expressions in the front end then serialize them to JSON then parse the JSON again in the backend. Parsing expressions seems outside the scope of computer algebra, more of a front end task.

Also added the Variable expression type to the backend.