### PR TITLE
Rule fixes

### DIFF
--- a/cas/src/derivation_rules.rs
+++ b/cas/src/derivation_rules.rs
@@ -57,6 +57,7 @@ mod subtract_exponents_on_fractions;
 mod sum_coefficients_of_terms;
 mod tan_identity;
 mod trig_reflections;
+mod unit_fraction;
 
 pub trait DerivationRule {
     /// Produces a set of equivalent expressions from the given
@@ -119,6 +120,7 @@ pub static ALL_RULES: RwLock<&[&(dyn DerivationRule + Sync)]> = RwLock::new(&[
     &integral_to_natural_log::IntegralToNaturalLog {},
     &integral_of_negative_one::FlipNegativeOne {},
     &split_fractions_over_addition::SplitFractionsAddition {},
+    &unit_fraction::UnitFraction {},
 ]);
 
 /// These rules always bring us closer to a simplified expression. Once all of
@@ -156,4 +158,5 @@ pub static IDENTITIES: RwLock<&[&(dyn DerivationRule + Sync)]> = RwLock::new(&[
     &cancel_negatives::CancelNegatives {},
     &additive_identity::AdditiveIdentity {},
     &derivative_of_constant::DerivativeOfConst {},
+    &unit_fraction::UnitFraction {},
 ]);

--- a/cas/src/derivation_rules/evaluate_fractions.rs
+++ b/cas/src/derivation_rules/evaluate_fractions.rs
@@ -74,6 +74,9 @@ impl DerivationRule for EvaluateFractions {
         }
 
         let (n, d) = (num.value() / gcf, den.value() / gcf);
+        if n == 1 && d == 1 {
+            return vec![];
+        }
         let result = Fraction::of(
             product_of_iter(
                 &mut [Integer::of(n)].into_iter().chain(

--- a/cas/src/derivation_rules/unit_fraction.rs
+++ b/cas/src/derivation_rules/unit_fraction.rs
@@ -1,0 +1,30 @@
+use std::rc::Rc;
+
+use crate::{argument::Argument, expressions::Integer, Expression};
+
+use super::DerivationRule;
+
+/// x/x = 1
+pub struct UnitFraction {}
+
+impl DerivationRule for UnitFraction {
+    fn apply(&self, input: Expression) -> Vec<(Expression, Rc<Argument>)> {
+        let fraction = match input {
+            Expression::Fraction(ref f) => f,
+            _ => return vec![],
+        };
+
+        if fraction.numerator() != fraction.denominator() {
+            return vec![];
+        }
+
+        vec![(
+            Integer::of(1),
+            Argument::new(String::from("x/x = 1"), vec![input]),
+        )]
+    }
+
+    fn name(&self) -> String {
+        todo!()
+    }
+}


### PR DESCRIPTION
Create rule to turn x/x into 1. Stop reduce fractions rule from producing junk. 

If no solution is found during a step of an incremental derivation,  return a path to the newest equivalent.