### PR TITLE
Refactor deriver

### DIFF
--- a/cas-wasm-wrapper/Cargo.toml
+++ b/cas-wasm-wrapper/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 cas = { path = "../cas" }
 js-sys = "0.3.69"
+serde_json = "1.0.116"
 wasm-bindgen = "0.2.90"
 
 [dependencies.web-sys]

--- a/cas-wasm-wrapper/src/lib.rs
+++ b/cas-wasm-wrapper/src/lib.rs
@@ -1,23 +1,8 @@
+use serde_json::json;
 use wasm_bindgen::prelude::*;
 
 /// Just provide wrappers for the functions in cas. This is only a compilation
 /// target.
-
-#[wasm_bindgen]
-pub fn simplify_with_steps(
-    json_expression: &str,
-    search_depth: u32,
-    optimizer: &str,
-    max_derivations: u32,
-) -> String {
-    cas::simplify_with_steps(
-        json_expression,
-        search_depth,
-        optimizer,
-        None,
-        max_derivations,
-    )
-}
 
 #[wasm_bindgen]
 pub fn get_all_equivalents(
@@ -30,22 +15,21 @@ pub fn get_all_equivalents(
 }
 
 #[wasm_bindgen]
-pub fn simplify_incremental(
-    json_expression: &str,
-    depth: u32,
-    optimizer: &str,
-    max_derived: u32,
-    callback: &js_sys::Function,
-) {
-    cas::simplify_with_steps_incremental(
-        json_expression,
-        depth,
-        optimizer,
-        None,
-        max_derived,
-        &|res| {
-            let this = JsValue::NULL;
-            let _ = callback.call1(&this, &JsValue::from(res));
-        },
-    );
+pub struct DerivationHandle {
+    handle: cas::DerivationHandle,
+}
+
+#[wasm_bindgen]
+impl DerivationHandle {
+    pub fn do_pass(&mut self, new_derivations: u32) -> String {
+        json!(self.handle.do_pass(new_derivations)).to_string()
+    }
+}
+
+#[wasm_bindgen]
+pub fn simplify_incremental(json_expression: &str, optimizer: &str) -> DerivationHandle {
+    match cas::simplify_incremental_js(json_expression, optimizer) {
+        Ok(handle) => DerivationHandle { handle },
+        Err(m) => panic!("{}", m),
+    }
 }

--- a/cas/src/cmd_line.rs
+++ b/cas/src/cmd_line.rs
@@ -1,5 +1,5 @@
 use cas::{
-    get_all_equivalents, read_object_from_json, simplify_with_steps_internal, BruteForceProfile,
+    get_all_equivalents, read_object_from_json, simplify_internal, BruteForceProfile,
     DerivationDebugInfo, EvaluateFirstProfile, OptimizationProfile,
 };
 use clap::Parser;
@@ -73,7 +73,7 @@ pub fn main() -> anyhow::Result<()> {
             _ => panic!("Invalid optimizer"),
         };
 
-        let result = &simplify_with_steps_internal(
+        let result = &simplify_internal(
             &expression,
             depth,
             opt,

--- a/cas/src/derivation_rules/integration_by_substitution.rs
+++ b/cas/src/derivation_rules/integration_by_substitution.rs
@@ -79,12 +79,12 @@ impl DerivationRule for IntegrateBySubstitution {
 /// which doesn't include derivatives of the given variable,
 /// or None if the derivative couldn't be solved.
 fn simplest_derivative(exp: &Expression, variable: &Expression) -> Option<Expression> {
-    let mut deriver = Deriver::new(Box::new(DerivativesOnlyProfile::new()));
     let mut graph = Graph::new();
     graph.add_node(Derivative::of(exp.clone(), variable.clone()));
-    deriver.expand(&mut graph, 10, 100);
+    let mut deriver = Deriver::new(graph, Box::new(DerivativesOnlyProfile::new()), None, None);
+    deriver.expand_to_constraint(10, 100);
 
-    graph
+    deriver
         .node_references()
         .map(|x| x.1.clone())
         .filter(|x| children_rec(x).all(|e| !matches!(e, Expression::Derivative(_))))

--- a/cas/src/derivation_rules/unit_fraction.rs
+++ b/cas/src/derivation_rules/unit_fraction.rs
@@ -25,6 +25,6 @@ impl DerivationRule for UnitFraction {
     }
 
     fn name(&self) -> String {
-        todo!()
+        String::from("UnitFraction")
     }
 }

--- a/ui/CasWorker.ts
+++ b/ui/CasWorker.ts
@@ -4,39 +4,47 @@ import { CasWorkerMsg, IncrementalResult } from "./CasWorkerTypes"
 
 importScripts("./cas-wasm/index.js")
 
-let ready = false
-
 // @ts-ignore
 const { simplify_incremental } = wasm_bindgen
 
 console.log("Initializing worker")
 
-onmessage = function (this, e: MessageEvent<CasWorkerMsg>) {
-    function res() {
-        const { expressionJson } = e.data
-
-        simplify_incremental(
-            expressionJson,
-            20,
-            "evaluate_first",
-            1000,
-            function (inc: string) {
-                const result = JSON.parse(inc) as IncrementalResult
-                postMessage(result)
-            }
-        )
-    }
-    new Promise(() => {
-        setInterval(() => {
-            if (ready) {
-                res()
-            }
-        })
-    })
-}
 async function init_wasm_in_worker() {
     // @ts-ignore
     await wasm_bindgen("./cas-wasm/index_bg.wasm")
-    ready = true
+
+    let incrementingPromise: Promise<void>;
+    let queuedExpression: string | null = null;
+
+    onmessage = function (this, e: MessageEvent<CasWorkerMsg>) {
+        const { expressionJson, cancel } = e.data
+
+        if (expressionJson === queuedExpression) {
+            return 
+        }
+        queuedExpression = expressionJson
+        if (cancel) {
+            postMessage({failed: "cancelled", finished: true} as IncrementalResult)
+            return
+        }
+
+        incrementingPromise = new Promise((res, _) => {
+            let expression: string = expressionJson
+            let handle = simplify_incremental(expressionJson, "evaluate_first")
+            let count = 0;
+
+            let incrementInterval = setInterval(() => {
+                count++
+                const incrementalResult = JSON.parse(handle.do_pass(10)) as IncrementalResult
+                postMessage(incrementalResult)
+                if (expression !== queuedExpression || count >= 1000 || incrementalResult.finished || incrementalResult.failed) {
+                    handle.free()
+                    clearInterval(incrementInterval)
+                    res()
+                    return
+                }
+            }, 1)
+        })
+    }
 }
 init_wasm_in_worker()

--- a/ui/CasWorkerTypes.ts
+++ b/ui/CasWorkerTypes.ts
@@ -1,8 +1,11 @@
 
 export type CasWorkerMsg = {
+    cancel: boolean
     expressionJson: string
 }
 
 export type IncrementalResult = {
     steps: string[]
+    failed: string | null
+    finished: boolean
 }


### PR DESCRIPTION
Reshape Deriver to support incremental derivation in a way that makes sense. Redo the web worker to complete derivation work on a timed interval rather than passing control to the deriver and getting callbacks. This allows us to keep the same webworker between operations, saving us from recompiling the web assembly every time.