### PR TITLE
Adapt graph view to display backend info

### DIFF
--- a/cas-wasm-wrapper/src/lib.rs
+++ b/cas-wasm-wrapper/src/lib.rs
@@ -1,8 +1,7 @@
 use serde_json::json;
 use wasm_bindgen::prelude::*;
 
-/// Just provide wrappers for the functions in cas. This is only a compilation
-/// target.
+/// Just provide wrappers for the functions in cas.
 
 #[wasm_bindgen]
 pub fn get_all_equivalents(
@@ -17,19 +16,68 @@ pub fn get_all_equivalents(
 #[wasm_bindgen]
 pub struct DerivationHandle {
     handle: cas::DerivationHandle,
+    last_graph_checked: cas::graph::Graph,
 }
 
 #[wasm_bindgen]
 impl DerivationHandle {
+    /// Does a pass of the derivation process.
     pub fn do_pass(&mut self, new_derivations: u32) -> String {
         json!(self.handle.do_pass(new_derivations)).to_string()
+    }
+
+    /// Gets the difference in the constructed derivation graph since the
+    /// last time this function was called.
+    pub fn get_graph_difference(&mut self) -> String {
+        let new_graph: &cas::graph::Graph = self.handle.get_deriver();
+        let diff: Vec<_> = new_graph
+            .clone()
+            .into_nodes_edges()
+            .1
+            .iter()
+            .filter(|edge| {
+                !self
+                    .last_graph_checked
+                    .contains_edge(edge.source(), edge.target())
+            })
+            .map(|edge| {
+                json!({
+                    "source": new_graph.node_weight(edge.source()).unwrap().to_json(),
+                    "edge": format!("{:?}", edge.weight),
+                    "target": new_graph.node_weight(edge.target()).unwrap().to_json(),
+                })
+            })
+            .collect();
+
+        self.last_graph_checked = new_graph.clone();
+
+        json!(diff).to_string()
     }
 }
 
 #[wasm_bindgen]
 pub fn simplify_incremental(json_expression: &str, optimizer: &str) -> DerivationHandle {
     match cas::simplify_incremental_js(json_expression, optimizer) {
-        Ok(handle) => DerivationHandle { handle },
+        Ok(handle) => DerivationHandle {
+            handle,
+            last_graph_checked: cas::graph::Graph::new(),
+        },
         Err(m) => panic!("{}", m),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_1() {
+        let mut handle =
+            simplify_incremental("[\"Sum\", {\"num\": 1}, {\"num\": 1}]", "evaluate_first");
+        assert_eq!(handle.get_graph_difference(), "[]");
+
+        let _ = handle.do_pass(10);
+
+        assert_ne!(handle.get_graph_difference(), "[]");
     }
 }

--- a/cas/src/derivation_rules.rs
+++ b/cas/src/derivation_rules.rs
@@ -155,17 +155,19 @@ pub static ARITHMETIC: RwLock<&[&(dyn DerivationRule + Sync)]> = RwLock::new(&[
 /// These rules could by applied in any order one at a time and in every case
 /// that an equivalent is derived, the expression it was derived from may be
 /// safetly ignored.
+///
+/// These identities are applied in order.
 pub static IDENTITIES: RwLock<&[&(dyn DerivationRule + Sync)]> = RwLock::new(&[
-    &integral_of_constant::IntegralOfConst {},
-    &one_to_any_power::OneToAnything {},
-    &multiplicative_identity::MultiplicativeIdentity {},
-    &division_identity::DivisionIdentity {},
-    &log_of_one::LogOfOne {},
-    &exponent_to_zero::ExponentToZero {},
-    &cancel_negatives::CancelNegatives {},
-    &additive_identity::AdditiveIdentity {},
-    &derivative_of_constant::DerivativeOfConst {},
-    &unit_fraction::UnitFraction {},
-    &anything_times_zero::AnythingTimesZero {},
     &undefined_fractions::UndefinedFractions {},
+    &anything_times_zero::AnythingTimesZero {},
+    &additive_identity::AdditiveIdentity {},
+    &cancel_negatives::CancelNegatives {},
+    &exponent_to_zero::ExponentToZero {},
+    &log_of_one::LogOfOne {},
+    &multiplicative_identity::MultiplicativeIdentity {},
+    &one_to_any_power::OneToAnything {},
+    &division_identity::DivisionIdentity {},
+    &unit_fraction::UnitFraction {},
+    &integral_of_constant::IntegralOfConst {},
+    &derivative_of_constant::DerivativeOfConst {},
 ]);

--- a/cas/src/derivation_rules/make_common_denominators.rs
+++ b/cas/src/derivation_rules/make_common_denominators.rs
@@ -8,11 +8,11 @@ use crate::{
 
 use super::DerivationRule;
 
-/**
-* Accepts sums with at least one fraction term and at least one non-fraction term.
-* For each fraction term, converts all non-fraction terms to fractions with
-* the same base.
-*/
+/// Accepts sums with at least one fraction term and at least one non-fraction term.
+/// For each fraction term, converts all non-fraction terms to fractions with
+/// the same base.
+///
+/// Doesn't convert integrals.
 pub struct MakeCommonDenominators {}
 
 impl DerivationRule for MakeCommonDenominators {
@@ -39,6 +39,7 @@ impl DerivationRule for MakeCommonDenominators {
             equivalents.push(sum_of_iter(&mut sum.terms().iter().map(
                 |term| match term {
                     Expression::Fraction(_) => term.clone(),
+                    Expression::Integral(_) => term.clone(),
                     x => Fraction::of(
                         product_of(&[x.clone(), denominator.clone()]),
                         denominator.clone(),
@@ -49,6 +50,7 @@ impl DerivationRule for MakeCommonDenominators {
 
         equivalents
             .into_iter()
+            .filter(|exp| exp != &input)
             .map(|exp| {
                 (
                     exp,
@@ -67,7 +69,11 @@ impl DerivationRule for MakeCommonDenominators {
 
 #[cfg(test)]
 mod tests {
-    use crate::{convenience_expressions::v, expressions::sum::sum_of};
+    use crate::{
+        convenience_expressions::v,
+        derivation_rules::helpers::expect_no_result,
+        expressions::{sum::sum_of, Integral},
+    };
 
     use super::*;
 
@@ -84,6 +90,11 @@ mod tests {
                 Fraction::of(product_of(&[v("x"), v("z")]), v("z")),
                 Fraction::of(v("y"), v("z"))
             ])
-        )
+        );
+
+        expect_no_result(
+            &rule,
+            sum_of(&[Integral::of(v("x"), v("x")), Fraction::of(v("a"), v("b"))]),
+        );
     }
 }

--- a/cas/src/deriver.rs
+++ b/cas/src/deriver.rs
@@ -116,7 +116,8 @@ impl Deriver {
                     let result = self.graph.add_node(derived.clone());
                     e.insert(result);
                     derivations += 1;
-                    self.derivation_queue.push((u32::MAX - complexity_rec(&derived), result));
+                    self.derivation_queue
+                        .push((u32::MAX - complexity_rec(&derived), result));
                     result
                 } else {
                     self.node_indices[&derived]

--- a/cas/src/graph.rs
+++ b/cas/src/graph.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 /**
 * A type of relationship between two expressions.
 */
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RelType {
     Equal,
 }
@@ -18,7 +18,7 @@ pub enum RelType {
 * which derived it. There may be no arguments,
 * meaning this relationship wasn't derived.
 */
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Relationship {
     pub r_type: RelType,
     pub derived_from: HashSet<Rc<Argument>>,
@@ -28,4 +28,3 @@ pub struct Relationship {
 * Graph type for expressions
 */
 pub type Graph = DiGraph<Expression, Relationship, u32>;
-

--- a/cas/src/lib.rs
+++ b/cas/src/lib.rs
@@ -127,6 +127,10 @@ impl DerivationHandle {
             finished,
         }
     }
+
+    pub fn get_deriver(&self) -> &Deriver {
+        &self.deriver
+    }
 }
 
 fn build_path(graph: &Graph, start_exp: &Expression, start: NodeIndex, end: NodeIndex) -> Path {

--- a/public/integrator.html
+++ b/public/integrator.html
@@ -1,24 +1,31 @@
 <!doctype html>
 
 <html>
-    <head>
-        <title>Integrator</title>
-        <link rel="icon" href="icon.ico" />
-        <meta charset="UTF-8" />
-        <link rel="stylesheet" href="css/style.css" />
-        <script>
-            var exports = {}
-        </script>
-        <script
-            async
-            src="https://polyfill.io/v3/polyfill.min.js?features=es6"
-        ></script>
-        <script id="MathJax-script" src="mathjax/tex-mml-chtml.js"></script>
-    </head>
-    <body id="body"> 
-        <textarea id="input" cols="30" rows="1"></textarea>
-        <div id="outputbox"></div>
-    </body>
 
-    <script src="graphPage.js"></script>
+<head>
+    <title>Integrator</title>
+    <link rel="icon" href="icon.ico" />
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="css/style.css" />
+    <script>
+        var exports = {}
+    </script>
+    <script async src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" src="mathjax/tex-mml-chtml.js"></script>
+    <!--MathQuill Imports-->
+    <link rel="stylesheet" href="mathquill/mathquill.css" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="mathquill/mathquill.js"></script>
+    <script>
+        var MQ = MathQuill.getInterface(2)
+    </script>
+</head>
+
+<body id="body">
+    <div id="input"></div>
+    <div id="outputbox"></div>
+</body>
+
+<script src="graphPage.js" type="module"></script>
+
 </html>

--- a/public/integrator.html
+++ b/public/integrator.html
@@ -19,13 +19,37 @@
     <script>
         var MQ = MathQuill.getInterface(2)
     </script>
+    <style>
+        #input {
+            font-size: 2em;
+            text-align: center;
+            padding: 0.5em;
+            width: 100%;
+            margin-top: 2em;
+        }
+
+        #outputbox {
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+        }
+    </style>
+    <!--Import Google Icon Font-->
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <!--Import materialize.css-->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
 </head>
 
 <body id="body">
-    <div id="input"></div>
+    <div class="container row" style="z-index: 20">
+        <div id="input" class="col s12"></div>
+    </div>
     <div id="outputbox"></div>
 </body>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 <script src="graphPage.js" type="module"></script>
 
 </html>

--- a/ui/CasWorkerTypes.ts
+++ b/ui/CasWorkerTypes.ts
@@ -1,12 +1,35 @@
-
-export type CasWorkerMsg = {
+export interface CasWorkerMsg {
     cancel: boolean
     expressionJson: string
+    operation: "simplify" | "graph"
 }
 
-export type IncrementalResult = {
+export interface IncrementalResult {
+    /**
+     * The json string representing the expression of the operation.
+     */
     forProblem: string
-    steps: string[]
+    /**
+     * The operation has failed for the given reason.
+     */
     failed: string | null
+    /**
+     * The operation is compelete and no further results will come.
+     */
     finished: boolean
+}
+
+export interface IncrementalSimplifyResult  extends IncrementalResult {
+    steps: string[]
+} 
+
+export interface IncrementalGraphResult extends IncrementalResult {
+    // The new graph data added in this pass
+    newData: {
+        // Expression json 
+        source: string,
+        // Argument text
+        edge: string,
+        target: string, 
+    }[]
 }

--- a/ui/LoadPrimaryPage.ts
+++ b/ui/LoadPrimaryPage.ts
@@ -9,6 +9,8 @@ import { GivenEdge, Graph } from "./mathlib/Graph"
 import { CasWorkerMsg, IncrementalGraphResult } from "./CasWorkerTypes"
 import { parseExpressionJSON } from "./mathlib/expressions-from-json"
 import { Relationship } from "./mathlib/Relationship"
+import { Argument } from "./mathlib/Argument"
+import { setOf } from "./mathlib/util/ThingsThatShouldBeInTheStdLib"
 
 declare const MQ: any
 
@@ -77,7 +79,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 
         for (const { source, target } of newData) {
-            graph.addEdge(parseExpressionJSON(source), parseExpressionJSON(target), new GivenEdge(Relationship.Equal))
+            let n = parseExpressionJSON(source)
+            let n1 = parseExpressionJSON(target)
+            graph.addEdge(n, n1, new Argument(setOf(n), {n: n, r: Relationship.Equal, n1: n1}, "From backend", "unknown"))
         }
 
         graphView.setGraph(graph, new Set([expression]))

--- a/ui/mathlib/tests/WebGraphView.test.ts
+++ b/ui/mathlib/tests/WebGraphView.test.ts
@@ -1,7 +1,5 @@
-import { WebGraphView } from "../uielements/WebGraphView"
 import { a, b, c, equivalenceArgument, sum } from "../ConvenientExpressions"
 import { Graph } from "../Graph"
-import { Argument } from "../Argument"
 
 test("WebGraphView constructs", () => {
     const graph = new Graph()

--- a/ui/mathlib/uielements/WebGraphView.ts
+++ b/ui/mathlib/uielements/WebGraphView.ts
@@ -312,7 +312,10 @@ export class WebGraphView extends HTMLDivElement {
                                 levels.get(depth - 1)!.has(n) &&
                                 lastPositions!.has(n)
                         )[0]
-                    const idealAngle = lastPositions.get(parent)!
+                    // TODO: This fixes a bug where the ideal angle is undefined.
+                    // It should never be undefined in the first place.
+                    // Figure out why it is undefined.
+                    const idealAngle = lastPositions.get(parent) ?? 0
                     idealAngles.set(n, idealAngle)
                 }
 
@@ -573,6 +576,7 @@ export class WebGraphView extends HTMLDivElement {
         assert(GraphMinipulator.isConnected(this.graph), "Graph not connected")
         if (this.showArguments)
             assert(this.graph.getNodes().size == this.nodes.size)
+        assert(for_all(this.graph.getNodes(), (n) => n != null && n != undefined), "Graph contains null node")
     }
 
     private graph: Graph


### PR DESCRIPTION
The integrator.html page now takes in latex expressions and uses the backend like the solver page. This page displays the derivation graph as a graph and will hopefully help in optimization.